### PR TITLE
security: remove legacy sha256 hashing, HMAC-SHA256 only

### DIFF
--- a/platform/api/api_keys.py
+++ b/platform/api/api_keys.py
@@ -7,7 +7,6 @@ import hmac
 import os
 
 HASH_PREFIX = "hmac-sha256$"
-LEGACY_HASH_PREFIX = "sha256$"
 
 _API_KEY_SECRET = os.environ.get("RWC_API_KEY_SECRET", "rwc-default-key-secret")
 
@@ -21,16 +20,8 @@ def hash_api_key(raw_api_key: str) -> str:
     return f"{HASH_PREFIX}{digest}"
 
 
-def _legacy_hash_api_key(raw_api_key: str) -> str:
-    digest = hashlib.sha256(raw_api_key.encode("utf-8")).hexdigest()
-    return f"{LEGACY_HASH_PREFIX}{digest}"
-
-
 def is_hashed_api_key(value: str | None) -> bool:
-    return bool(
-        value
-        and (value.startswith(HASH_PREFIX) or value.startswith(LEGACY_HASH_PREFIX))
-    )
+    return bool(value and value.startswith(HASH_PREFIX))
 
 
 def verify_api_key(raw_api_key: str, stored_value: str | None) -> bool:
@@ -39,20 +30,14 @@ def verify_api_key(raw_api_key: str, stored_value: str | None) -> bool:
         return False
     if stored_value.startswith(HASH_PREFIX):
         return hmac.compare_digest(hash_api_key(raw_api_key), stored_value)
-    if stored_value.startswith(LEGACY_HASH_PREFIX):
-        return hmac.compare_digest(_legacy_hash_api_key(raw_api_key), stored_value)
     # Legacy plaintext compatibility; should be migrated to hashed on rotation.
     return hmac.compare_digest(raw_api_key, stored_value)
 
 
 def find_agent_by_api_key(db, raw_api_key: str):
-    """Find agent row by API key with hashed-first + legacy fallback lookup."""
+    """Find agent row by API key (HMAC-SHA256 hashed lookup with plaintext fallback)."""
     row = db.execute("SELECT * FROM agents WHERE api_key = ?", (hash_api_key(raw_api_key),)).fetchone()
     if row:
         return row
-    # Legacy sha256$ fallback
-    legacy = _legacy_hash_api_key(raw_api_key)
-    row = db.execute("SELECT * FROM agents WHERE api_key = ?", (legacy,)).fetchone()
-    if row:
-        return row
+    # Plaintext fallback for unmigrated keys
     return db.execute("SELECT * FROM agents WHERE api_key = ?", (raw_api_key,)).fetchone()


### PR DESCRIPTION
## What
Remove legacy bare SHA256 hashing path from api_keys.py, keep only HMAC-SHA256.

## Why
CodeQL alerts #7 and #8 — weak cryptographic hashing on sensitive data.
Alpha stage, no legacy data to migrate.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass locally (288 passed)
- [x] No mock/fake data
- [x] Build passes
- [x] Reviewed own diff

## Gate
- [x] G0: Requirements clear
- [x] G2: Tests adequate