### PR TITLE
docs: add Japanese Quick Start locale

### DIFF
--- a/docs-site/.vitepress/config.mts
+++ b/docs-site/.vitepress/config.mts
@@ -178,6 +178,18 @@ export default defineConfig({
         },
       },
     },
+    ja: {
+      label: '日本語',
+      lang: 'ja-JP',
+      link: '/ja/',
+      themeConfig: {
+        nav: [
+          { text: 'クイックスタート', link: '/ja/' },
+          { text: 'ガイド', link: '/getting-started/introduction' },
+          { text: 'GitHub', link: 'https://github.com/brianzhibo-design/RealWorldClaw' },
+        ],
+      },
+    },
   },
 
   themeConfig: {

--- a/docs-site/ja/index.md
+++ b/docs-site/ja/index.md
@@ -1,0 +1,38 @@
+---
+layout: home
+
+hero:
+  name: RealWorldClaw
+  text: AIに“身体”を与えよう
+  tagline: 標準モジュール + 3Dプリントで、AIを現実世界のデバイスへ。すべてのAIに身体を、すべての3Dプリンタに役割を。
+  image:
+    src: /hero.svg
+    alt: RealWorldClaw
+  actions:
+    - theme: brand
+      text: クイックスタート
+      link: /ja/
+    - theme: alt
+      text: GitHubを見る
+      link: https://github.com/brianzhibo-design/RealWorldClaw
+
+features:
+  - icon: 🧩
+    title: モジュール式システム
+    details: 6つの標準モジュールを磁気RWC Busで接続。スナップしてすぐ使える、自動認識、ホットスワップ対応。フルキットは約15ドル。
+  - icon: 🖨️
+    title: すべてを3Dプリント
+    details: STLをダウンロードして造形し、モジュールを差し込むだけ。使っていないプリンタがスマートハードウェア工場になります。
+  - icon: 🤖
+    title: AIが身体を持つ
+    details: Coreモジュール（4ドル）から始め、耳・顔・心臓・筋肉のように機能を段階的に拡張できます。
+  - icon: 🌐
+    title: Makerネットワーク
+    details: プリンタがなくても大丈夫。分散型のMakerネットワークが近くで造形し、あなたのもとへ届けます。
+  - icon: ⚡
+    title: 6ドルから開始
+    details: Core + 1モジュールでスタート。モジュールを追加するたびに、AIの能力が自動的に広がります。
+  - icon: 🔓
+    title: オープンソース
+    details: MITライセンス。ハードウェア仕様、ファームウェア、プラットフォームまで全面公開。独自モジュールの設計・公開も歓迎です。
+---


### PR DESCRIPTION
## Summary\n- add Japanese homepage translation at docs-site/ja/index.md\n- add ja locale entry in VitePress config\n- wire locale navigation between EN/ZH/JA via locale switcher\n\n## Testing\n- npm run build (docs-site) -> fails in clean environment because vitepress is not installed locally ()\n\nFixes #8