### PR TITLE
feat(cli): add --json output for status and printer

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -9,9 +9,14 @@
   "main": "src/index.js",
   "scripts": {
     "start": "node bin/rwc.js",
-    "link": "npm link"
+    "link": "npm link",
+    "test": "node --test tests/*.test.js"
   },
-  "keywords": ["3d-printing", "cli", "marketplace"],
+  "keywords": [
+    "3d-printing",
+    "cli",
+    "marketplace"
+  ],
   "license": "MIT",
   "dependencies": {
     "chalk": "^5.3.0",

--- a/cli/src/commands/printer.js
+++ b/cli/src/commands/printer.js
@@ -9,33 +9,62 @@ const statusColor = (s) => {
   return chalk.red(s);
 };
 
+export function normalizePrinters(data) {
+  return data.printers || data;
+}
+
+export function formatPrinterListJson(printers) {
+  return {
+    printers: printers.map((p) => ({
+      id: p.id,
+      name: p.name,
+      model: p.model || '-',
+      status: p.status,
+    })),
+  };
+}
+
+async function renderPrinterList(json = false) {
+  const spinner = ora('获取打印机列表...').start();
+  try {
+    const data = await api.get('/printers');
+    const printers = normalizePrinters(data);
+    spinner.stop();
+
+    if (json) {
+      console.log(JSON.stringify(formatPrinterListJson(printers), null, 2));
+      return;
+    }
+
+    if (!printers.length) {
+      heading('🖨️  暂无连接的打印机');
+      return;
+    }
+
+    heading('🖨️  打印机列表');
+    table(
+      ['ID', '名称', '型号', '状态'],
+      printers.map((p) => [p.id, p.name, p.model || '-', statusColor(p.status)])
+    );
+  } catch (err) {
+    spinner.fail('获取失败');
+    handleError(err);
+  }
+}
+
 export function registerPrinterCommand(program) {
-  const cmd = program
-    .command('printer')
-    .description('打印机管理');
+  const cmd = program.command('printer').description('打印机管理').option('--json', '以 JSON 格式输出打印机列表');
+
+  cmd.action(async (options) => {
+    await renderPrinterList(Boolean(options.json));
+  });
 
   cmd
     .command('list')
     .description('列出连接的打印机')
-    .action(async () => {
-      const spinner = ora('获取打印机列表...').start();
-      try {
-        const data = await api.get('/printers');
-        spinner.stop();
-        const printers = data.printers || data;
-        if (!printers.length) {
-          heading('🖨️  暂无连接的打印机');
-          return;
-        }
-        heading('🖨️  打印机列表');
-        table(
-          ['ID', '名称', '型号', '状态'],
-          printers.map(p => [p.id, p.name, p.model || '-', statusColor(p.status)])
-        );
-      } catch (err) {
-        spinner.fail('获取失败');
-        handleError(err);
-      }
+    .option('--json', '以 JSON 格式输出')
+    .action(async (options) => {
+      await renderPrinterList(Boolean(options.json));
     });
 
   cmd

--- a/cli/src/commands/status.js
+++ b/cli/src/commands/status.js
@@ -1,23 +1,40 @@
 import ora from 'ora';
 import { api } from '../lib/api.js';
-import { heading, label, table, handleError, info } from '../lib/output.js';
+import { heading, label, handleError } from '../lib/output.js';
+
+export function formatStatusJson(data) {
+  return {
+    server: data.server || '在线',
+    version: data.version || 'unknown',
+    printersOnline: data.printersOnline ?? 0,
+    activeOrders: data.activeOrders ?? 0,
+    modulesCount: data.modulesCount ?? 0,
+  };
+}
 
 export function registerStatusCommand(program) {
   program
     .command('status')
     .description('显示系统状态（连接的打印机、活动订单等）')
-    .action(async () => {
+    .option('--json', '以 JSON 格式输出')
+    .action(async (options) => {
       const spinner = ora('获取系统状态...').start();
       try {
         const data = await api.get('/status');
+        const formatted = formatStatusJson(data);
         spinner.stop();
 
+        if (options.json) {
+          console.log(JSON.stringify(formatted, null, 2));
+          return;
+        }
+
         heading('🏭 RealWorldClaw 系统状态');
-        label('服务器', data.server || '在线');
-        label('版本', data.version || 'unknown');
-        label('打印机在线', String(data.printersOnline ?? 0));
-        label('活动订单', String(data.activeOrders ?? 0));
-        label('可用模块', String(data.modulesCount ?? 0));
+        label('服务器', formatted.server);
+        label('版本', formatted.version);
+        label('打印机在线', String(formatted.printersOnline));
+        label('活动订单', String(formatted.activeOrders));
+        label('可用模块', String(formatted.modulesCount));
         console.log();
       } catch (err) {
         spinner.fail('获取状态失败');

--- a/cli/tests/printer-json.test.js
+++ b/cli/tests/printer-json.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizePrinters, formatPrinterListJson } from '../src/commands/printer.js';
+
+test('normalizePrinters supports wrapped response', () => {
+  const data = { printers: [{ id: 'p1', name: 'A1', model: 'X', status: 'online' }] };
+  assert.equal(normalizePrinters(data).length, 1);
+});
+
+test('formatPrinterListJson returns stable machine-readable fields', () => {
+  const result = formatPrinterListJson([
+    { id: 'p1', name: 'A1', model: '', status: 'idle' },
+    { id: 'p2', name: 'B2', status: 'printing' },
+  ]);
+
+  assert.deepEqual(result, {
+    printers: [
+      { id: 'p1', name: 'A1', model: '-', status: 'idle' },
+      { id: 'p2', name: 'B2', model: '-', status: 'printing' },
+    ],
+  });
+});

--- a/cli/tests/status-json.test.js
+++ b/cli/tests/status-json.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { formatStatusJson } from '../src/commands/status.js';
+
+test('formatStatusJson maps fields', () => {
+  const result = formatStatusJson({
+    server: 'ok',
+    version: '1.0.0',
+    printersOnline: 3,
+    activeOrders: 2,
+    modulesCount: 5,
+  });
+
+  assert.deepEqual(result, {
+    server: 'ok',
+    version: '1.0.0',
+    printersOnline: 3,
+    activeOrders: 2,
+    modulesCount: 5,
+  });
+});
+
+test('formatStatusJson applies defaults', () => {
+  const result = formatStatusJson({});
+  assert.equal(result.server, '在线');
+  assert.equal(result.version, 'unknown');
+  assert.equal(result.printersOnline, 0);
+  assert.equal(result.activeOrders, 0);
+  assert.equal(result.modulesCount, 0);
+});


### PR DESCRIPTION
## Summary\n- add  option to \n- add  option to  (root command) and \n- extract stable JSON formatter helpers for status/printer payloads\n- add unit tests for JSON formatters (2 per command path)\n\n## Testing\n- 
> @realworldclaw/cli@0.1.0 test
> node --test tests/*.test.js

TAP version 13
# Subtest: normalizePrinters supports wrapped response
ok 1 - normalizePrinters supports wrapped response
  ---
  duration_ms: 0.52225
  type: 'test'
  ...
# Subtest: formatPrinterListJson returns stable machine-readable fields
ok 2 - formatPrinterListJson returns stable machine-readable fields
  ---
  duration_ms: 0.572208
  type: 'test'
  ...
# Subtest: formatStatusJson maps fields
ok 3 - formatStatusJson maps fields
  ---
  duration_ms: 1.011583
  type: 'test'
  ...
# Subtest: formatStatusJson applies defaults
ok 4 - formatStatusJson applies defaults
  ---
  duration_ms: 0.061916
  type: 'test'
  ...
1..4
# tests 4
# suites 0
# pass 4
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 139.30875\n\nFixes #10